### PR TITLE
DesignSystem 모듈 분리 및 구조 정리

### DIFF
--- a/MLS/MLS.xcodeproj/project.pbxproj
+++ b/MLS/MLS.xcodeproj/project.pbxproj
@@ -51,10 +51,16 @@
 		779A490E2E1AD26700ABDE4F /* BookmarkFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 779A490C2E1AD26700ABDE4F /* BookmarkFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		779A49102E1AD26D00ABDE4F /* BookmarkFeatureInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 779A490F2E1AD26D00ABDE4F /* BookmarkFeatureInterface.framework */; };
 		779A49112E1AD26D00ABDE4F /* BookmarkFeatureInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 779A490F2E1AD26D00ABDE4F /* BookmarkFeatureInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		77A293312F79989200845081 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77A293302F79989200845081 /* DesignSystem.framework */; };
+		77A293322F79989200845081 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77A293302F79989200845081 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		77B1F9952EE06A4E00AE4B4D /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = 77B1F9942EE06A4E00AE4B4D /* RxGesture */; };
 		77E260412EEABEC40059E889 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 77E260402EEABEC40059E889 /* Settings.bundle */; };
 		77EB18D62DED9256004FB380 /* AuthFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77EB18D52DED9256004FB380 /* AuthFeature.framework */; };
 		77EB18D72DED9256004FB380 /* AuthFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77EB18D52DED9256004FB380 /* AuthFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		77FA68B82F72C9C10064B6EB /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 77FA68B72F72C9C10064B6EB /* RxCocoa */; };
+		77FA68BA2F72C9C10064B6EB /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 77FA68B92F72C9C10064B6EB /* RxSwift */; };
+		77FA68BC2F72C9C70064B6EB /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 77FA68BB2F72C9C70064B6EB /* SnapKit */; };
+		77FA68BE2F72CA490064B6EB /* MLSDesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 77FA68BD2F72CA490064B6EB /* MLSDesignSystem */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +101,17 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		77A293332F79989200845081 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				77A293322F79989200845081 /* DesignSystem.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -127,9 +144,12 @@
 		7777F7072E9EAC0D00F53D68 /* MyPageFeatureInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MyPageFeatureInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		779A490C2E1AD26700ABDE4F /* BookmarkFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BookmarkFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		779A490F2E1AD26D00ABDE4F /* BookmarkFeatureInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BookmarkFeatureInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		77A293302F79989200845081 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77BEB0402DBA84B0002FFCFC /* MLSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MLSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77E260402EEABEC40059E889 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = Settings.bundle; path = MLS/Resource/Settings.bundle; sourceTree = "<group>"; };
 		77EB18D52DED9256004FB380 /* AuthFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AuthFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		77FA68752F72C6D80064B6EB /* MLSDesignSystem */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = MLSDesignSystem; path = Presentation/MLSDesignSystem; sourceTree = "<group>"; };
+		77FA687A2F72C7360064B6EB /* MLSDesignSystemExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MLSDesignSystemExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -139,6 +159,13 @@
 				Resource/Info.plist,
 			);
 			target = 087D3EE72DA7972C002F924D /* MLS */;
+		};
+		77FA688B2F72C7380064B6EB /* Exceptions for "MLSDesignSystemExample" folder in "MLSDesignSystemExample" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 77FA68792F72C7360064B6EB /* MLSDesignSystemExample */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -154,6 +181,14 @@
 		77BEB0412DBA84B0002FFCFC /* MLSTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = MLSTests;
+			sourceTree = "<group>";
+		};
+		77FA687B2F72C7360064B6EB /* MLSDesignSystemExample */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				77FA688B2F72C7380064B6EB /* Exceptions for "MLSDesignSystemExample" folder in "MLSDesignSystemExample" target */,
+			);
+			path = MLSDesignSystemExample;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -198,6 +233,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77FA68772F72C7360064B6EB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77FA68BC2F72C9C70064B6EB /* SnapKit in Frameworks */,
+				77FA68BA2F72C9C10064B6EB /* RxSwift in Frameworks */,
+				77A293312F79989200845081 /* DesignSystem.framework in Frameworks */,
+				77FA68BE2F72CA490064B6EB /* MLSDesignSystem in Frameworks */,
+				77FA68B82F72C9C10064B6EB /* RxCocoa in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -249,6 +296,7 @@
 		084A25312DB93A5400C395C0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				77A293302F79989200845081 /* DesignSystem.framework */,
 				7777F7062E9EAC0D00F53D68 /* MyPageFeature.framework */,
 				7777F7072E9EAC0D00F53D68 /* MyPageFeatureInterface.framework */,
 				7777F7002E9EAB8400F53D68 /* BookmarkFeature.framework */,
@@ -277,11 +325,13 @@
 		087D3EDF2DA7972C002F924D = {
 			isa = PBXGroup;
 			children = (
+				77FA68752F72C6D80064B6EB /* MLSDesignSystem */,
 				77E260402EEABEC40059E889 /* Settings.bundle */,
 				77660AD12DD0D361007A4EF3 /* KakaoConfig.xcconfig */,
 				085A7F742DAF99570046663F /* .swiftlint.yml */,
 				087D3EEA2DA7972C002F924D /* MLS */,
 				77BEB0412DBA84B0002FFCFC /* MLSTests */,
+				77FA687B2F72C7360064B6EB /* MLSDesignSystemExample */,
 				084A25312DB93A5400C395C0 /* Frameworks */,
 				087D3EE92DA7972C002F924D /* Products */,
 			);
@@ -292,6 +342,7 @@
 			children = (
 				087D3EE82DA7972C002F924D /* MLS.app */,
 				77BEB0402DBA84B0002FFCFC /* MLSTests.xctest */,
+				77FA687A2F72C7360064B6EB /* MLSDesignSystemExample.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -357,6 +408,33 @@
 			productReference = 77BEB0402DBA84B0002FFCFC /* MLSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		77FA68792F72C7360064B6EB /* MLSDesignSystemExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77FA688C2F72C7380064B6EB /* Build configuration list for PBXNativeTarget "MLSDesignSystemExample" */;
+			buildPhases = (
+				77FA68762F72C7360064B6EB /* Sources */,
+				77FA68772F72C7360064B6EB /* Frameworks */,
+				77FA68782F72C7360064B6EB /* Resources */,
+				77A293332F79989200845081 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				77FA687B2F72C7360064B6EB /* MLSDesignSystemExample */,
+			);
+			name = MLSDesignSystemExample;
+			packageProductDependencies = (
+				77FA68B72F72C9C10064B6EB /* RxCocoa */,
+				77FA68B92F72C9C10064B6EB /* RxSwift */,
+				77FA68BB2F72C9C70064B6EB /* SnapKit */,
+				77FA68BD2F72CA490064B6EB /* MLSDesignSystem */,
+			);
+			productName = MLSDesignSystemExample;
+			productReference = 77FA687A2F72C7360064B6EB /* MLSDesignSystemExample.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -364,7 +442,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1620;
+				LastSwiftUpdateCheck = 2610;
 				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					087D3EE72DA7972C002F924D = {
@@ -373,6 +451,9 @@
 					77BEB03F2DBA84B0002FFCFC = {
 						CreatedOnToolsVersion = 16.2;
 						TestTargetID = 087D3EE72DA7972C002F924D;
+					};
+					77FA68792F72C7360064B6EB = {
+						CreatedOnToolsVersion = 26.1.1;
 					};
 				};
 			};
@@ -427,6 +508,7 @@
 			targets = (
 				087D3EE72DA7972C002F924D /* MLS */,
 				77BEB03F2DBA84B0002FFCFC /* MLSTests */,
+				77FA68792F72C7360064B6EB /* MLSDesignSystemExample */,
 			);
 		};
 /* End PBXProject section */
@@ -443,6 +525,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		77BEB03E2DBA84B0002FFCFC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77FA68782F72C7360064B6EB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -481,6 +570,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		77BEB03C2DBA84B0002FFCFC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77FA68762F72C7360064B6EB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -737,6 +833,78 @@
 			};
 			name = Release;
 		};
+		77FA688D2F72C7380064B6EB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MLSDesignSystemExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.donggle.MLSDesignSystemExample.MLSDesignSystemExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		77FA688E2F72C7380064B6EB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MLSDesignSystemExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.donggle.MLSDesignSystemExample.MLSDesignSystemExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -763,6 +931,15 @@
 			buildConfigurations = (
 				77BEB0462DBA84B0002FFCFC /* Debug */,
 				77BEB0472DBA84B0002FFCFC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77FA688C2F72C7380064B6EB /* Build configuration list for PBXNativeTarget "MLSDesignSystemExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77FA688D2F72C7380064B6EB /* Debug */,
+				77FA688E2F72C7380064B6EB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -883,6 +1060,25 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 77B1F9932EE06A4E00AE4B4D /* XCRemoteSwiftPackageReference "RxGesture" */;
 			productName = RxGesture;
+		};
+		77FA68B72F72C9C10064B6EB /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 08ED49202DCFDE9C002C21A2 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		77FA68B92F72C9C10064B6EB /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 08ED49202DCFDE9C002C21A2 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		77FA68BB2F72C9C70064B6EB /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 08ED4DAF2DCFE098002C21A2 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+		77FA68BD2F72CA490064B6EB /* MLSDesignSystem */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MLSDesignSystem;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MLS/MLSCore/Sources/MLSCore/BaseController/BaseViewController.swift
+++ b/MLS/MLSCore/Sources/MLSCore/BaseController/BaseViewController.swift
@@ -1,0 +1,68 @@
+import os
+import UIKit
+
+
+import RxKeyboard
+import RxSwift
+
+open class BaseViewController: UIViewController {
+    private let disposeBag = DisposeBag()
+
+    
+    open var isBottomTabbarHidden: Bool = false {
+        didSet {
+            setBottomTabBarHidden(isBottomTabbarHidden, animated: false)
+        }
+    }
+
+    public init() {
+        super.init(nibName: nil, bundle: nil)
+        os_log("➕init: \(String(describing: self))")
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        os_log("➖deinit: \(String(describing: self))")
+    }
+}
+
+// MARK: - Life Cycle
+extension BaseViewController {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+
+    override open func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setBottomTabBarHidden(isBottomTabbarHidden, animated: animated)
+    }
+}
+
+// MARK: - SetUp
+private extension BaseViewController {
+    func configureUI() {
+        navigationController?.navigationBar.isHidden = true
+        view.backgroundColor = .systemBackground
+    }
+}
+
+// MARK: - Methods
+public extension BaseViewController {
+    func setupKeyboard(inset: CGFloat = 0, completion: @escaping (CGFloat) -> Void) {
+        RxKeyboard.instance.visibleHeight
+            .drive(onNext: { [weak self] height in
+                guard let self = self else { return }
+                let safeBottom = self.view.safeAreaInsets.bottom
+                let inset = height > 0
+                    ? height - safeBottom + inset
+                    : inset
+                completion(inset)
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSCore/Sources/MLSCore/BaseController/BaseViewController.swift
+++ b/MLS/MLSCore/Sources/MLSCore/BaseController/BaseViewController.swift
@@ -1,7 +1,6 @@
 import os
 import UIKit
 
-
 import RxKeyboard
 import RxSwift
 

--- a/MLS/MLSCore/Sources/MLSCore/BaseController/BaseViewController.swift
+++ b/MLS/MLSCore/Sources/MLSCore/BaseController/BaseViewController.swift
@@ -8,13 +8,6 @@ import RxSwift
 open class BaseViewController: UIViewController {
     private let disposeBag = DisposeBag()
 
-    
-    open var isBottomTabbarHidden: Bool = false {
-        didSet {
-            setBottomTabBarHidden(isBottomTabbarHidden, animated: false)
-        }
-    }
-
     public init() {
         super.init(nibName: nil, bundle: nil)
         os_log("➕init: \(String(describing: self))")
@@ -35,11 +28,6 @@ extension BaseViewController {
     override open func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-    }
-
-    override open func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        setBottomTabBarHidden(isBottomTabbarHidden, animated: animated)
     }
 }
 

--- a/MLS/MLSCore/Sources/MLSCore/Extension/UIViewController+.swift
+++ b/MLS/MLSCore/Sources/MLSCore/Extension/UIViewController+.swift
@@ -1,6 +1,0 @@
-import UIKit
-
-public extension UIViewController {
-    func setBottomTabBarHidden(_ hidden: Bool, animated: Bool) {
-    }
-}

--- a/MLS/MLSCore/Sources/MLSCore/Extension/UIViewController+.swift
+++ b/MLS/MLSCore/Sources/MLSCore/Extension/UIViewController+.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+public extension UIViewController {
+    func setBottomTabBarHidden(_ hidden: Bool, animated: Bool) {
+    }
+}

--- a/MLS/MLSDesignSystemExample/Application/AppDelegate.swift
+++ b/MLS/MLSDesignSystemExample/Application/AppDelegate.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+import MLSDesignSystem
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        FontManager.registerFonts()
+        return true
+    }
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
+}

--- a/MLS/MLSDesignSystemExample/Application/SceneDelegate.swift
+++ b/MLS/MLSDesignSystemExample/Application/SceneDelegate.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: windowScene)
+        window?.rootViewController = UINavigationController(rootViewController: ViewController())
+        window?.makeKeyAndVisible()
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+    }
+}

--- a/MLS/MLSDesignSystemExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/MLS/MLSDesignSystemExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MLS/MLSDesignSystemExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/MLS/MLSDesignSystemExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MLS/MLSDesignSystemExample/Assets.xcassets/Contents.json
+++ b/MLS/MLSDesignSystemExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MLS/MLSDesignSystemExample/Base.lproj/LaunchScreen.storyboard
+++ b/MLS/MLSDesignSystemExample/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/MLS/MLSDesignSystemExample/ComponentsTest/BadgeTestController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/BadgeTestController.swift
@@ -1,0 +1,71 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxSwift
+import SnapKit
+
+final class BadgeTestController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    private let currentBadge = Badge(style: .currentQuest)
+    private let preBadge = Badge(style: .preQuest)
+    private let nextBadge = Badge(style: .nextQuest)
+    private let elementBadge = Badge(style: .element("불 약점"))
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        title = "Badge"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension BadgeTestController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+}
+
+// MARK: - SetUp
+private extension BadgeTestController {
+    func addViews() {
+        view.addSubview(currentBadge)
+        view.addSubview(preBadge)
+        view.addSubview(nextBadge)
+        view.addSubview(elementBadge)
+    }
+
+    func setupConstraints() {
+        currentBadge.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+
+        preBadge.snp.makeConstraints { make in
+            make.top.equalTo(currentBadge.snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        nextBadge.snp.makeConstraints { make in
+            make.top.equalTo(preBadge.snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        elementBadge.snp.makeConstraints { make in
+            make.top.equalTo(nextBadge.snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/CardListTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/CardListTestViewController.swift
@@ -1,0 +1,147 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class CardListTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    private let cardList = CardList()
+
+    private let mainTextTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "main"
+        view.text = "text"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let mainTextTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "main"
+        return label
+    }()
+
+    private let subTextTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "sub"
+        view.text = "text"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let subTextTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "sub"
+        return label
+    }()
+
+    private let cardListToggle = ToggleBox(text: "isBookmark")
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "CardList"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension CardListTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+        bind()
+    }
+}
+
+// MARK: - SetUp
+private extension CardListTestViewController {
+    func addViews() {
+        view.addSubview(cardList)
+        view.addSubview(mainTextTextLabel)
+        view.addSubview(mainTextTextField)
+        view.addSubview(subTextTextLabel)
+        view.addSubview(subTextTextField)
+        view.addSubview(cardListToggle)
+    }
+
+    func setupConstraints() {
+        cardList.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        mainTextTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(cardList.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        mainTextTextField.snp.makeConstraints { make in
+            make.top.equalTo(mainTextTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        subTextTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(mainTextTextField.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        subTextTextField.snp.makeConstraints { make in
+            make.top.equalTo(subTextTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        cardListToggle.snp.makeConstraints { make in
+            make.top.equalTo(subTextTextField.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+//        ImageLoader.shared.loadImage(stringURL: "https://maplestory.io/api/gms/62/mob/2100101/render/stand") { [weak self] image in
+//            if let image {
+//                DispatchQueue.main.async {
+//                    self?.cardList.setImage(image: image, backgroundColor: .listMap)
+//                }
+//            } else {
+//                print("fail to load image")
+//            }
+//        }
+    }
+
+    func bind() {
+        mainTextTextField.rx.text
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.cardList.mainText = text
+            }
+            .disposed(by: disposeBag)
+
+        subTextTextField.rx.text
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.cardList.subText = text
+            }
+            .disposed(by: disposeBag)
+
+        cardListToggle.toggle.rx.isOn
+            .withUnretained(self)
+            .subscribe { (owner, isOn) in
+                owner.cardList.isIconSelected = isOn
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/CardListTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/CardListTestViewController.swift
@@ -111,15 +111,7 @@ private extension CardListTestViewController {
 
     func configureUI() {
         view.backgroundColor = .systemBackground
-//        ImageLoader.shared.loadImage(stringURL: "https://maplestory.io/api/gms/62/mob/2100101/render/stand") { [weak self] image in
-//            if let image {
-//                DispatchQueue.main.async {
-//                    self?.cardList.setImage(image: image, backgroundColor: .listMap)
-//                }
-//            } else {
-//                print("fail to load image")
-//            }
-//        }
+        self.cardList.setImage(image: DesignSystemAsset.image(named: "testImage"), backgroundColor: .listMap)
     }
 
     func bind() {

--- a/MLS/MLSDesignSystemExample/ComponentsTest/CheckBoxButtonTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/CheckBoxButtonTestViewController.swift
@@ -1,0 +1,211 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class CheckBoxButtonTestViewController: UIViewController {
+    // MARK: - Properties
+    private var disposeBag = DisposeBag()
+    private var normalButton = CheckBoxButton(style: .normal, mainTitle: nil, subTitle: nil)
+    private var smallButton = CheckBoxButton(style: .listSmall, mainTitle: nil, subTitle: nil)
+    private var mediumButton = CheckBoxButton(style: .listMedium, mainTitle: nil, subTitle: nil)
+    private var largeButton = CheckBoxButton(style: .listLarge, mainTitle: nil, subTitle: nil)
+
+    private let typeSegmentControl: UISegmentedControl = {
+        let items = ["normal", "listSmall", "listMedium", "listLarge"]
+        let control = UISegmentedControl(items: items)
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+
+    private let mainTitleTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "MainTitle"
+        view.text = "MainTitle"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let subTitleTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "SubTitle"
+        view.text = "SubTitle"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let mainTitleTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "MainTitle"
+        return label
+    }()
+
+    private let subTitleTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "SubTitle"
+        return label
+    }()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "CheckBoxButton"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+// MARK: - Life Cycle
+extension CheckBoxButtonTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.addViews()
+        self.setupConstraints()
+        self.configureUI()
+        self.bind()
+    }
+}
+
+// MARK: - SetUp
+private extension CheckBoxButtonTestViewController {
+    func addViews() {
+        view.addSubview(normalButton)
+        view.addSubview(smallButton)
+        view.addSubview(mediumButton)
+        view.addSubview(largeButton)
+        view.addSubview(typeSegmentControl)
+        view.addSubview(mainTitleTextLabel)
+        view.addSubview(mainTitleTextField)
+        view.addSubview(subTitleTextLabel)
+        view.addSubview(subTitleTextField)
+    }
+
+    func setupConstraints() {
+        normalButton.snp.makeConstraints { make in
+            make.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+        }
+
+        smallButton.snp.makeConstraints { make in
+            make.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+        }
+
+        mediumButton.snp.makeConstraints { make in
+            make.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+        }
+
+        largeButton.snp.makeConstraints { make in
+            make.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+        }
+
+        typeSegmentControl.snp.makeConstraints { make in
+            make.top.equalTo(normalButton.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        mainTitleTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(typeSegmentControl.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        mainTitleTextField.snp.makeConstraints { make in
+            make.top.equalTo(mainTitleTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        subTitleTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(mainTitleTextField.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        subTitleTextField.snp.makeConstraints { make in
+            make.top.equalTo(subTitleTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+
+    func bind() {
+        normalButton.rx.tap
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.normalButton.isSelected.toggle()
+            }
+            .disposed(by: disposeBag)
+
+        smallButton.rx.tap
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.smallButton.isSelected.toggle()
+            }
+            .disposed(by: disposeBag)
+
+        mediumButton.rx.tap
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.mediumButton.isSelected.toggle()
+            }
+            .disposed(by: disposeBag)
+
+        largeButton.rx.tap
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.largeButton.isSelected.toggle()
+            }
+            .disposed(by: disposeBag)
+
+        typeSegmentControl.rx.selectedSegmentIndex
+            .withUnretained(self)
+            .subscribe { (owner, index) in
+                switch index {
+                case 0:
+                    owner.normalButton.isHidden = false
+                    owner.smallButton.isHidden = true
+                    owner.mediumButton.isHidden = true
+                    owner.largeButton.isHidden = true
+                case 1:
+                    owner.normalButton.isHidden = true
+                    owner.smallButton.isHidden = false
+                    owner.mediumButton.isHidden = true
+                    owner.largeButton.isHidden = true
+                case 2:
+                    owner.normalButton.isHidden = true
+                    owner.smallButton.isHidden = true
+                    owner.mediumButton.isHidden = false
+                    owner.largeButton.isHidden = true
+                default:
+                    owner.normalButton.isHidden = true
+                    owner.smallButton.isHidden = true
+                    owner.mediumButton.isHidden = true
+                    owner.largeButton.isHidden = false
+                }
+            }
+            .disposed(by: disposeBag)
+
+        mainTitleTextField.rx.text
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.normalButton.mainTitle = text
+                owner.smallButton.mainTitle = text
+                owner.mediumButton.mainTitle = text
+                owner.largeButton.mainTitle = text
+            }
+            .disposed(by: disposeBag)
+
+        subTitleTextField.rx.text
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.normalButton.subTitle = text
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/CollectionListTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/CollectionListTestViewController.swift
@@ -1,0 +1,54 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxSwift
+import SnapKit
+
+final class CollectionListTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+
+    let collection = CollectionList()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "CollectionList"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension CollectionListTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.addViews()
+        self.setupConstraints()
+        self.configureUI()
+    }
+}
+
+// MARK: - SetUp
+private extension CollectionListTestViewController {
+    func addViews() {
+        self.view.addSubview(collection)
+    }
+
+    func setupConstraints() {
+        collection.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        self.view.backgroundColor = .neutral200
+        collection.setTitle(text: "글자수는 10글자 이후부터 생략입니다.")
+        collection.setSubtitle(text: "$n개")
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/CommonButtonTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/CommonButtonTestViewController.swift
@@ -1,0 +1,119 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class CommonButtonTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    private let commonButton = CommonButton(style: .normal, title: "NormalTitle", disabledTitle: "DisabledTitle")
+    private let textButton = CommonButton(style: .text, title: "NormalTitle", disabledTitle: "DisabledTitle")
+    private let borderButton = CommonButton(style: .border, title: "NormalTitle", disabledTitle: "DisabledTitle")
+
+    private let typeSegmentControl: UISegmentedControl = {
+        let items = ["normal", "text", "border"]
+        let control = UISegmentedControl(items: items)
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+
+    private let buttonStateToggle = ToggleBox(text: "isEnabled")
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "CommonButton"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension CommonButtonTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+        bind()
+    }
+}
+
+// MARK: - SetUp
+private extension CommonButtonTestViewController {
+    func addViews() {
+        view.addSubview(commonButton)
+        view.addSubview(textButton)
+        view.addSubview(borderButton)
+        view.addSubview(typeSegmentControl)
+        view.addSubview(buttonStateToggle)
+    }
+
+    func setupConstraints() {
+        commonButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        textButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        borderButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        typeSegmentControl.snp.makeConstraints { make in
+            make.top.equalTo(textButton.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        buttonStateToggle.snp.makeConstraints { make in
+            make.top.equalTo(typeSegmentControl.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        self.view.backgroundColor = .systemBackground
+        self.title = "CommonButton"
+    }
+
+    func bind() {
+        self.typeSegmentControl.rx.selectedSegmentIndex
+            .withUnretained(self)
+            .subscribe { owner, selectedIndex in
+                switch selectedIndex {
+                case 0:
+                    owner.commonButton.isHidden = false
+                    owner.textButton.isHidden = true
+                    owner.borderButton.isHidden = true
+                case 1:
+                    owner.commonButton.isHidden = true
+                    owner.textButton.isHidden = false
+                    owner.borderButton.isHidden = true
+                default:
+                    owner.commonButton.isHidden = true
+                    owner.textButton.isHidden = true
+                    owner.borderButton.isHidden = false
+                }
+            }
+            .disposed(by: disposeBag)
+
+        self.buttonStateToggle.toggle.rx.isOn
+            .withUnretained(self)
+            .subscribe { (owner, isOn) in
+                owner.commonButton.isEnabled = isOn
+                owner.textButton.isEnabled = isOn
+                owner.borderButton.isEnabled = isOn
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/DictionaryDetailViewTestController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/DictionaryDetailViewTestController.swift
@@ -1,0 +1,75 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxSwift
+import SnapKit
+
+final class DictionaryDetailViewTestController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    private let first = DictionaryDetailListView()
+    private let second = DictionaryDetailListView()
+    private let third = DictionaryDetailListView()
+    private let forth = DictionaryDetailListView()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        title = "DictionaryDetailView"
+        first.update(clickableMainText: "mainText", additionalText: "text", clickableSubText: "text")
+        second.update(mainText: "mainText", clickableSubText: "text")
+        third.update(mainText: "mainText", subText: "text")
+        forth.update(clickableMainText: "mainText", clickableSubText: "text")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension DictionaryDetailViewTestController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+}
+
+// MARK: - SetUp
+private extension DictionaryDetailViewTestController {
+    func addViews() {
+        view.addSubview(first)
+        view.addSubview(second)
+        view.addSubview(third)
+        view.addSubview(forth)
+    }
+
+    func setupConstraints() {
+        first.snp.makeConstraints { make in
+            make.horizontalEdges.centerY.equalToSuperview()
+        }
+
+        second.snp.makeConstraints { make in
+            make.top.equalTo(first.snp.bottom).offset(16)
+            make.horizontalEdges.equalToSuperview()
+        }
+
+        third.snp.makeConstraints { make in
+            make.top.equalTo(second.snp.bottom).offset(16)
+            make.horizontalEdges.equalToSuperview()
+        }
+
+        forth.snp.makeConstraints { make in
+            make.top.equalTo(third.snp.bottom).offset(16)
+            make.horizontalEdges.equalToSuperview()
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/DropDwonBoxTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/DropDwonBoxTestViewController.swift
@@ -1,0 +1,161 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class DropDownBoxTextViewController: UIViewController {
+    // MARK: - Properties
+    private var disposeBag = DisposeBag()
+    private var dropDownBox = DropDownBox(items: [DropDownBox.Item(name: "하나", id: 1), DropDownBox.Item(name: "둘", id: 2)])
+    private lazy var inputBox = dropDownBox.inputBox
+
+    private let labelTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "label"
+        view.text = "label"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let placeHolderTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "placeHolder"
+        view.text = "placeHolder"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let countTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "count"
+        view.text = "4"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        view.keyboardType = .numberPad
+        return view
+    }()
+
+    private let labelTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "label"
+        return label
+    }()
+
+    private let placeHolderTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "placeHolder"
+        return label
+    }()
+
+    private let countTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "메뉴개수"
+        return label
+    }()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "DropDownBox"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+// MARK: - Life Cycle
+extension DropDownBoxTextViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.addViews()
+        self.setupConstraints()
+        self.configureUI()
+        self.bind()
+    }
+}
+
+// MARK: - SetUp
+private extension DropDownBoxTextViewController {
+    func addViews() {
+        view.addSubview(labelTextLabel)
+        view.addSubview(labelTextField)
+        view.addSubview(placeHolderTextLabel)
+        view.addSubview(placeHolderTextField)
+        view.addSubview(countTextLabel)
+        view.addSubview(countTextField)
+        view.addSubview(dropDownBox)
+    }
+
+    func setupConstraints() {
+        dropDownBox.snp.makeConstraints { make in
+            make.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+        }
+
+        labelTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(dropDownBox.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        labelTextField.snp.makeConstraints { make in
+            make.top.equalTo(labelTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        placeHolderTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(labelTextField.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        placeHolderTextField.snp.makeConstraints { make in
+            make.top.equalTo(placeHolderTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        countTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(placeHolderTextField.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        countTextField.snp.makeConstraints { make in
+            make.top.equalTo(countTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+
+    func bind() {
+        labelTextField.rx.text
+            .withUnretained(self)
+            .subscribe { owner, text in
+                owner.inputBox.label.attributedText = .makeStyledString(font: .b_s_r, text: text, color: .neutral700, alignment: .left)
+            }
+            .disposed(by: disposeBag)
+
+        placeHolderTextField.rx.text
+            .withUnretained(self)
+            .subscribe { owner, text in
+                owner.inputBox.textField.attributedPlaceholder = .makeStyledString(font: .b_m_r, text: text, color: .neutral500, alignment: .left)
+            }
+            .disposed(by: disposeBag)
+
+        countTextField.rx.text
+            .withUnretained(self)
+            .subscribe { (owner, count) in
+                guard let count = Int(count ?? "") else { return }
+                owner.dropDownBox.items = []
+                for index in 1...count {
+                    owner.dropDownBox.items.append(DropDownBox.Item(name: "메뉴\(index)", id: index))
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/ErrorMessageTextViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/ErrorMessageTextViewController.swift
@@ -1,0 +1,88 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class ErrorMessageTextViewController: UIViewController {
+    // MARK: - Properties
+    private var disposeBag = DisposeBag()
+    private var errorMessage = ErrorMessage(message: nil)
+
+    private let messageTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "message"
+        view.text = "error"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let messageTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "message"
+        return label
+    }()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "ErrorMessage"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+// MARK: - Life Cycle
+extension ErrorMessageTextViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.addViews()
+        self.setupConstraints()
+        self.configureUI()
+        self.bind()
+    }
+}
+
+// MARK: - SetUp
+private extension ErrorMessageTextViewController {
+    func addViews() {
+        view.addSubview(errorMessage)
+        view.addSubview(messageTextLabel)
+        view.addSubview(messageTextField)
+    }
+
+    func setupConstraints() {
+        errorMessage.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        messageTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(errorMessage.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        messageTextField.snp.makeConstraints { make in
+            make.top.equalTo(messageTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+
+    func bind() {
+        messageTextField.rx.text
+            .withUnretained(self)
+            .subscribe { owner, message in
+                owner.errorMessage.label.attributedText = .makeStyledString(font: .b_s_r, text: message, color: .error900)
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/GuideAlertTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/GuideAlertTestViewController.swift
@@ -1,0 +1,105 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class GuideAlertTestViewController: UIViewController {
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+
+    let oneButton = CommonButton(style: .normal, title: "oneButtonModal", disabledTitle: nil)
+    let twoButton = CommonButton(style: .normal, title: "twoButtonModal", disabledTitle: nil)
+    let logoutButton = CommonButton(style: .normal, title: "logoutButtonModal", disabledTitle: nil)
+    let withdrawButton = CommonButton(style: .normal, title: "withdrawButtonModal", disabledTitle: nil)
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "GuideAlert"
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension GuideAlertTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+        bind()
+    }
+}
+
+// MARK: - SetUp
+private extension GuideAlertTestViewController {
+    func addViews() {
+        view.addSubview(oneButton)
+        view.addSubview(twoButton)
+        view.addSubview(logoutButton)
+        view.addSubview(withdrawButton)
+    }
+
+    func setupConstraints() {
+        oneButton.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        twoButton.snp.makeConstraints { make in
+            make.bottom.equalTo(oneButton.snp.top).offset(-16)
+            make.centerX.equalToSuperview()
+        }
+
+        logoutButton.snp.makeConstraints { make in
+            make.bottom.equalTo(twoButton.snp.top).offset(-16)
+            make.centerX.equalToSuperview()
+        }
+
+        withdrawButton.snp.makeConstraints { make in
+            make.bottom.equalTo(logoutButton.snp.top).offset(-16)
+            make.centerX.equalToSuperview()
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+
+    func bind() {
+        oneButton.rx.tap
+            .withUnretained(self)
+            .subscribe { _, _ in
+//                GuideAlertFactory.show(mainText: "버튼 하나", ctaText: "확인", ctaAction: {})
+            }
+            .disposed(by: disposeBag)
+
+        twoButton.rx.tap
+            .withUnretained(self)
+            .subscribe { _, _ in
+//                GuideAlertFactory.show(mainText: "버튼 두개", ctaText: "확인", cancelText: "취소", ctaAction: {})
+            }
+            .disposed(by: disposeBag)
+
+        logoutButton.rx.tap
+            .withUnretained(self)
+            .subscribe { _, _ in
+//                GuideAlertFactory.showAuthAlert(type: .logout, ctaAction: {})
+            }
+            .disposed(by: disposeBag)
+
+        withdrawButton.rx.tap
+            .withUnretained(self)
+            .subscribe { _, _ in
+//                GuideAlertFactory.showAuthAlert(type: .withdraw, ctaAction: {})
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/GuideAlertTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/GuideAlertTestViewController.swift
@@ -77,28 +77,28 @@ private extension GuideAlertTestViewController {
         oneButton.rx.tap
             .withUnretained(self)
             .subscribe { _, _ in
-//                GuideAlertFactory.show(mainText: "버튼 하나", ctaText: "확인", ctaAction: {})
+                GuideAlertFactory.show(mainText: "버튼 하나", ctaText: "확인", ctaAction: {})
             }
             .disposed(by: disposeBag)
 
         twoButton.rx.tap
             .withUnretained(self)
             .subscribe { _, _ in
-//                GuideAlertFactory.show(mainText: "버튼 두개", ctaText: "확인", cancelText: "취소", ctaAction: {})
+                GuideAlertFactory.show(mainText: "버튼 두개", ctaText: "확인", cancelText: "취소", ctaAction: {})
             }
             .disposed(by: disposeBag)
 
         logoutButton.rx.tap
             .withUnretained(self)
             .subscribe { _, _ in
-//                GuideAlertFactory.showAuthAlert(type: .logout, ctaAction: {})
+                GuideAlertFactory.showAuthAlert(type: .logout, ctaAction: {})
             }
             .disposed(by: disposeBag)
 
         withdrawButton.rx.tap
             .withUnretained(self)
             .subscribe { _, _ in
-//                GuideAlertFactory.showAuthAlert(type: .withdraw, ctaAction: {})
+                GuideAlertFactory.showAuthAlert(type: .withdraw, ctaAction: {})
             }
             .disposed(by: disposeBag)
     }

--- a/MLS/MLSDesignSystemExample/ComponentsTest/HeaderTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/HeaderTestViewController.swift
@@ -1,0 +1,157 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class HeaderTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    private let mainHeader = Header(style: .main, title: "메인")
+    private let filterHeader = Header(style: .filter, title: "필터")
+
+    private let typeSegmentControl: UISegmentedControl = {
+        let items = ["main", "filter"]
+        let control = UISegmentedControl(items: items)
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+
+    private let mainTextTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "text"
+        view.text = "text"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let mainTextTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "text"
+        return label
+    }()
+
+    private let filterTextTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "text"
+        view.text = "text"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let filterTextTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "text"
+        return label
+    }()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "Header"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension HeaderTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+        bind()
+    }
+}
+
+// MARK: - SetUp
+private extension HeaderTestViewController {
+    func addViews() {
+        view.addSubview(mainHeader)
+        view.addSubview(filterHeader)
+        view.addSubview(typeSegmentControl)
+        view.addSubview(mainTextTextLabel)
+        view.addSubview(mainTextTextField)
+        view.addSubview(filterTextTextLabel)
+        view.addSubview(filterTextTextField)
+    }
+
+    func setupConstraints() {
+        mainHeader.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        filterHeader.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        typeSegmentControl.snp.makeConstraints { make in
+            make.top.equalTo(mainHeader.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        mainTextTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(typeSegmentControl.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        mainTextTextField.snp.makeConstraints { make in
+            make.top.equalTo(mainTextTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        filterTextTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(mainTextTextField.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        filterTextTextField.snp.makeConstraints { make in
+            make.top.equalTo(filterTextTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        self.view.backgroundColor = .systemBackground
+    }
+
+    func bind() {
+        typeSegmentControl.rx.selectedSegmentIndex
+            .withUnretained(self)
+            .subscribe { owner, selectedIndex in
+                switch selectedIndex {
+                case 0:
+                    owner.mainHeader.isHidden = false
+                    owner.filterHeader.isHidden = true
+                default:
+                    owner.mainHeader.isHidden = true
+                    owner.filterHeader.isHidden = false
+                }
+            }
+            .disposed(by: disposeBag)
+
+        mainTextTextField.rx.text
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.mainHeader.titleLabel.attributedText = .makeStyledString(font: owner.mainHeader.style.titleFont, text: text)
+            }
+            .disposed(by: disposeBag)
+
+        filterTextTextField.rx.text
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.filterHeader.titleLabel.attributedText = .makeStyledString(font: owner.filterHeader.style.titleFont, text: text)
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/InputBoxTextViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/InputBoxTextViewController.swift
@@ -1,0 +1,179 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class InputBoxTextViewController: UIViewController {
+    // MARK: - Properties
+    private var disposeBag = DisposeBag()
+    private var inputBox = InputBox(label: "label", placeHodler: "placeHolder")
+
+    private let typeSegmentControl: UISegmentedControl = {
+        let items = ["edit", "error"]
+        let control = UISegmentedControl(items: items)
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+
+    private let labelTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "label"
+        view.text = "label"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let placeHolderTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "placeHolder"
+        view.text = "placeHolder"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let textTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "text"
+        view.text = "text"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let labelTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "label"
+        return label
+    }()
+
+    private let placeHolderTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "placeHolder"
+        return label
+    }()
+
+    private let textTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "text"
+        return label
+    }()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "InputBox"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+// MARK: - Life Cycle
+extension InputBoxTextViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.addViews()
+        self.setupConstraints()
+        self.configureUI()
+        self.bind()
+    }
+}
+
+// MARK: - SetUp
+private extension InputBoxTextViewController {
+    func addViews() {
+        view.addSubview(inputBox)
+        view.addSubview(typeSegmentControl)
+        view.addSubview(labelTextLabel)
+        view.addSubview(labelTextField)
+        view.addSubview(placeHolderTextLabel)
+        view.addSubview(placeHolderTextField)
+        view.addSubview(textTextLabel)
+        view.addSubview(textTextField)
+    }
+
+    func setupConstraints() {
+        inputBox.snp.makeConstraints { make in
+            make.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+        }
+
+        typeSegmentControl.snp.makeConstraints { make in
+            make.top.equalTo(inputBox.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        labelTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(typeSegmentControl.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        labelTextField.snp.makeConstraints { make in
+            make.top.equalTo(labelTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        placeHolderTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(labelTextField.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        placeHolderTextField.snp.makeConstraints { make in
+            make.top.equalTo(placeHolderTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        textTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(placeHolderTextField.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        textTextField.snp.makeConstraints { make in
+            make.top.equalTo(textTextLabel.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+
+    func bind() {
+        typeSegmentControl.rx.selectedSegmentIndex
+            .withUnretained(self)
+            .subscribe { (owner, index) in
+                if index == 0 {
+                    owner.inputBox.setType(type: .edit)
+                } else {
+                    owner.inputBox.setType(type: .error)
+                }
+            }
+            .disposed(by: disposeBag)
+
+        labelTextField.rx.text
+            .withUnretained(self)
+            .subscribe { owner, text in
+                owner.inputBox.label.attributedText = .makeStyledString(font: .b_s_r, text: text, color: .neutral700, alignment: .left)
+            }
+            .disposed(by: disposeBag)
+
+        placeHolderTextField.rx.text
+            .withUnretained(self)
+            .subscribe { owner, text in
+                owner.inputBox.textField.attributedPlaceholder = .makeStyledString(font: .b_m_r, text: text, color: .neutral500, alignment: .left)
+            }
+            .disposed(by: disposeBag)
+
+        textTextField.rx.text
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.inputBox.textField.attributedText = .makeStyledString(font: .b_m_r, text: text, alignment: .left)
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/NavigationBarTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/NavigationBarTestViewController.swift
@@ -1,0 +1,99 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class NavigationBarTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+
+    private let headerView1: NavigationBar = {
+        let view = NavigationBar(type: .withUnderLine("null"))
+        return view
+    }()
+
+    private let headerView2: NavigationBar = {
+        let view = NavigationBar(type: .arrowRightLeft)
+        return view
+    }()
+
+    private let headerView3: NavigationBar = {
+        let view = NavigationBar(type: .arrowLeft)
+        return view
+    }()
+
+    private let headerView4: NavigationBar = {
+        let view = NavigationBar(type: .withString("null"))
+        return view
+    }()
+
+    private let headerView5: NavigationBar = {
+        let view = NavigationBar(type: .collection("컬렉션 이름"))
+        return view
+    }()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "NavigationBar"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension NavigationBarTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+}
+
+// MARK: - SetUp
+private extension NavigationBarTestViewController {
+    func addViews() {
+        view.addSubview(headerView1)
+        view.addSubview(headerView2)
+        view.addSubview(headerView3)
+        view.addSubview(headerView4)
+        view.addSubview(headerView5)
+    }
+
+    func setupConstraints() {
+        headerView1.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        headerView2.snp.makeConstraints { make in
+            make.top.equalTo(headerView1.snp.bottom).offset(16)
+            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        headerView3.snp.makeConstraints { make in
+            make.top.equalTo(headerView2.snp.bottom).offset(16)
+            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        headerView4.snp.makeConstraints { make in
+            make.top.equalTo(headerView3.snp.bottom).offset(16)
+            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        headerView5.snp.makeConstraints { make in
+            make.top.equalTo(headerView4.snp.bottom).offset(16)
+            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/SearchBarTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/SearchBarTestViewController.swift
@@ -1,0 +1,61 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class SearchBarTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+
+    let searchBar: SearchBar = SearchBar()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "SearchBar"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension SearchBarTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.addViews()
+        self.setupConstraints()
+        self.configureUI()
+    }
+}
+
+// MARK: - SetUp
+private extension SearchBarTestViewController {
+    func addViews() {
+        view.addSubview(searchBar)
+    }
+
+    func setupConstraints() {
+        searchBar.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.horizontalEdges.equalToSuperview()
+        }
+    }
+
+    func configureUI() {
+        self.view.backgroundColor = .systemBackground
+        let tapGesture = UITapGestureRecognizer()
+        view.addGestureRecognizer(tapGesture)
+
+        tapGesture.rx.event
+            .bind { [weak self] _ in
+                self?.view.endEditing(true)
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/SnackBarTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/SnackBarTestViewController.swift
@@ -1,0 +1,61 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxSwift
+import SnapKit
+
+final class SnackBarTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+
+    let normalSnackBar = SnackBar(type: .normal, image: DesignSystemAsset.image(named: "appleLogo"), imageBackgroundColor: .listNPC, text: "제목제목", buttonText: "되돌리기", buttonAction: nil)
+
+    let deleteSnackBar = SnackBar(type: .delete, image: DesignSystemAsset.image(named: "testImage"), imageBackgroundColor: .listNPC, text: "제목제목", buttonText: "되돌리기", buttonAction: nil)
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "SnackBar"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension SnackBarTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+}
+
+// MARK: - SetUp
+private extension SnackBarTestViewController {
+    func addViews() {
+        view.addSubview(normalSnackBar)
+        view.addSubview(deleteSnackBar)
+    }
+
+    func setupConstraints() {
+        normalSnackBar.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        deleteSnackBar.snp.makeConstraints { make in
+            make.top.equalTo(normalSnackBar.snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+        }
+    }
+
+    func configureUI() {
+        self.view.backgroundColor = .systemBackground
+
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/StepIndicatorTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/StepIndicatorTestViewController.swift
@@ -1,0 +1,70 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxSwift
+import SnapKit
+
+final class StepIndicatorTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+
+    let firstIndicator = StepIndicator(circleCount: 3)
+    let secondIndicator = StepIndicator(circleCount: 3)
+    let thirdIndicator = StepIndicator(circleCount: 3)
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "StepIndicator"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension StepIndicatorTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+}
+
+// MARK: - SetUp
+private extension StepIndicatorTestViewController {
+    func addViews() {
+        view.addSubview(firstIndicator)
+        view.addSubview(secondIndicator)
+        view.addSubview(thirdIndicator)
+    }
+
+    func setupConstraints() {
+        firstIndicator.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        secondIndicator.snp.makeConstraints { make in
+            make.top.equalTo(firstIndicator.snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        thirdIndicator.snp.makeConstraints { make in
+            make.top.equalTo(secondIndicator.snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+
+        firstIndicator.selectIndicator(index: 0)
+        secondIndicator.selectIndicator(index: 1)
+        thirdIndicator.selectIndicator(index: 2)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/TagChipTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/TagChipTestViewController.swift
@@ -1,0 +1,157 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class TagChipTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    private let normalTagChip = TagChip(style: .normal, text: "text")
+    private let searchTagChip = TagChip(style: .search, text: "text")
+
+    private let typeSegmentControl: UISegmentedControl = {
+        let items = ["normal", "search"]
+        let control = UISegmentedControl(items: items)
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+
+    private let normalTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "normal"
+        return label
+    }()
+
+    private let normalTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "text"
+        view.text = "text"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let searchTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "search"
+        return label
+    }()
+
+    private let searchTextField: UITextField = {
+        let view = UITextField()
+        view.placeholder = "text"
+        view.text = "text"
+        view.layer.borderColor = UIColor.gray.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        title = "TagChip"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension TagChipTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+        bind()
+    }
+}
+
+// MARK: - SetUp
+private extension TagChipTestViewController {
+    func addViews() {
+        view.addSubview(normalTagChip)
+        view.addSubview(searchTagChip)
+        view.addSubview(typeSegmentControl)
+        view.addSubview(normalTextLabel)
+        view.addSubview(normalTextField)
+        view.addSubview(searchTextLabel)
+        view.addSubview(searchTextField)
+    }
+
+    func setupConstraints() {
+        normalTagChip.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        searchTagChip.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        typeSegmentControl.snp.makeConstraints { make in
+            make.top.equalTo(normalTagChip.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        normalTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(typeSegmentControl.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        normalTextField.snp.makeConstraints { make in
+            make.top.equalTo(normalTextLabel.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        searchTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(normalTextField.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        searchTextField.snp.makeConstraints { make in
+            make.top.equalTo(searchTextLabel.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+
+    func bind() {
+        typeSegmentControl.rx.selectedSegmentIndex
+            .withUnretained(self)
+            .subscribe { owner, selectedIndex in
+                switch selectedIndex {
+                case 0:
+                    owner.normalTagChip.isHidden = false
+                    owner.searchTagChip.isHidden = true
+                default:
+                    owner.normalTagChip.isHidden = true
+                    owner.searchTagChip.isHidden = false
+                }
+            }
+            .disposed(by: disposeBag)
+
+        normalTextField.rx.text.orEmpty
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.normalTagChip.text = text
+            }
+            .disposed(by: disposeBag)
+
+        searchTextField.rx.text.orEmpty
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.searchTagChip.text = text
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/TapButtonTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/TapButtonTestViewController.swift
@@ -1,0 +1,70 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class TapButtonTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    private let tapButton = TapButton(text: "text")
+
+    private let buttonStateToggle = ToggleBox(text: "isSelected")
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "TapButton"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension TapButtonTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addViews()
+        setupConstraints()
+        configureUI()
+        bind()
+    }
+}
+
+// MARK: - SetUp
+private extension TapButtonTestViewController {
+    func addViews() {
+        view.addSubview(tapButton)
+        view.addSubview(buttonStateToggle)
+    }
+
+    func setupConstraints() {
+        tapButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.centerX.equalToSuperview()
+        }
+
+        buttonStateToggle.snp.makeConstraints { make in
+            make.top.equalTo(tapButton.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+
+    func bind() {
+        buttonStateToggle.toggle.rx.isOn
+            .withUnretained(self)
+            .subscribe { (owner, isOn) in
+                owner.tapButton.isSelected = isOn
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/TextButtonTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/TextButtonTestViewController.swift
@@ -1,0 +1,47 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxSwift
+import SnapKit
+
+final class TextButtonTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+
+    let button = TextButton()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "TextButton"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension TextButtonTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .whiteMLS
+        addViews()
+        setupConstraints()
+    }
+}
+
+// MARK: - SetUp
+private extension TextButtonTestViewController {
+    func addViews() {
+        view.addSubview(button)
+    }
+
+    func setupConstraints() {
+        button.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+}

--- a/MLS/MLSDesignSystemExample/ComponentsTest/ToastMakerTestViewController.swift
+++ b/MLS/MLSDesignSystemExample/ComponentsTest/ToastMakerTestViewController.swift
@@ -1,0 +1,47 @@
+import UIKit
+
+import MLSDesignSystem
+
+import RxSwift
+import SnapKit
+
+final class ToastMakerTestViewController: UIViewController {
+
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+
+    let toast = Toast(message: "토스트 테스트")
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.title = "Toast"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Life Cycle
+extension ToastMakerTestViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .whiteMLS
+        addViews()
+        setupConstraints()
+    }
+}
+
+// MARK: - SetUp
+private extension ToastMakerTestViewController {
+    func addViews() {
+        view.addSubview(toast)
+    }
+
+    func setupConstraints() {
+        toast.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+}

--- a/MLS/MLSDesignSystemExample/Info.plist
+++ b/MLS/MLSDesignSystemExample/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/MLS/MLSDesignSystemExample/ViewController.swift
+++ b/MLS/MLSDesignSystemExample/ViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-import DesignSystem
+import MLSDesignSystem
 
 import RxCocoa
 import RxSwift
@@ -12,7 +12,6 @@ class ViewController: UIViewController {
         return view
     }()
 
-    // TabBar위치 정해지면 DesignSystem 의존성 제거 예정
     let bottomTabBarViewController = BottomTabBarController(viewControllers: [
         CheckBoxButtonTestViewController(),
         NavigationBarTestViewController(),

--- a/MLS/MLSDesignSystemExample/ViewController.swift
+++ b/MLS/MLSDesignSystemExample/ViewController.swift
@@ -1,0 +1,112 @@
+import UIKit
+
+import DesignSystem
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+class ViewController: UIViewController {
+    let tableView: UITableView = {
+        let view = UITableView(frame: .zero, style: .plain)
+        return view
+    }()
+
+    // TabBar위치 정해지면 DesignSystem 의존성 제거 예정
+    let bottomTabBarViewController = BottomTabBarController(viewControllers: [
+        CheckBoxButtonTestViewController(),
+        NavigationBarTestViewController(),
+        CommonButtonTestViewController(),
+        InputBoxTextViewController()
+    ], initialIndex: 1)
+
+    lazy var componentViews: [UIViewController] = [
+        CheckBoxButtonTestViewController(),
+        NavigationBarTestViewController(),
+        CommonButtonTestViewController(),
+        InputBoxTextViewController(),
+        DropDownBoxTextViewController(),
+        ToastMakerTestViewController(),
+        ErrorMessageTextViewController(),
+        StepIndicatorTestViewController(),
+        HeaderTestViewController(),
+        TapButtonTestViewController(),
+        TagChipTestViewController(),
+        GuideAlertTestViewController(),
+        CardListTestViewController(),
+        bottomTabBarViewController,
+        SearchBarTestViewController(),
+        CollectionListTestViewController(),
+        SnackBarTestViewController(),
+        BadgeTestController(),
+        DictionaryDetailViewTestController(),
+        TextButtonTestViewController()
+    ]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .systemBackground
+        tableView.dataSource = self
+        tableView.delegate = self
+        navigationItem.title = "MLS Design System"
+        bottomTabBarViewController.title = "BottomTabBar"
+
+        view.addSubview(tableView)
+        tableView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+}
+
+extension ViewController: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch section {
+        case 0:
+            return "Components"
+        default:
+            return nil
+        }
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch section {
+        case 0:
+            return componentViews.count
+        default:
+            return 0
+        }
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell()
+        let viewController: UIViewController
+
+        switch indexPath.section {
+        case 0:
+            viewController = componentViews[indexPath.row]
+        default:
+            return cell
+        }
+
+        cell.textLabel?.text = viewController.title
+        cell.selectionStyle = .none
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let nextController: UIViewController
+
+        switch indexPath.section {
+        case 0:
+            nextController = componentViews[indexPath.row]
+        default:
+            return
+        }
+
+        navigationController?.pushViewController(nextController, animated: true)
+    }
+}

--- a/MLS/Presentation/AuthFeature/AuthFeature/Login/LoginView.swift
+++ b/MLS/Presentation/AuthFeature/AuthFeature/Login/LoginView.swift
@@ -67,7 +67,7 @@ final class LoginView: UIView {
     }()
 
     private let appleLogoImageView: UIImageView = {
-        let image = DesignSystemAsset.image(named: "AppleLogo")
+        let image = DesignSystemAsset.image(named: "appleLogo")
         let view = UIImageView(image: image)
         view.contentMode = .scaleAspectFit
         return view


### PR DESCRIPTION
## 1. 모듈 구조 설계

DesignSystem은 Presentation 레이어에서 사용되는 순수 UI 요소만 관리하는 모듈로 구성했습니다.

```
MLSDesignSystem
 └─ Sources
    └─ MLSDesignSystem
       ├─ Components   : 최소 단위 UI 컴포넌트
       ├─ Layouts      : 여러 컴포넌트를 조합한 공통 View
       ├─ Factory      : UI 표시용 Factory (Toast, Snackbar 등)
       ├─ Resources    : Asset / Font / Image 등 리소스
       └─ Utils        : UI 사용을 돕는 Helper 및 Extension
```
DesignSystem은 앱 구조 요소를 포함하지 않고 순수 UI 모듈로 유지하는 것을 목표로 합니다.

## 2. 역할 재정의

기존 DesignSystem과 BaseFeature에는 다음과 같은 요소들이 포함되어 역할이 모호했습니다.
* TabBar 관련 구현
* BaseViewController
* 일부 인프라 의존 코드 (ImageLoader 등)

이를 해결하기 위해 각 모듈의 역할을 다음과 같이 재정의했습니다.

DesignSystem
* UI Components
* 공통 Layout View
* UI Factory (Toast, Snackbar 등)
* Font / Color / Image 리소스
* UI Extension
→ 순수 UI 모듈

## 3. 공용 View 이전

기존 Base 모듈에 위치하던 공통 View들을 DesignSystem으로 이전했습니다.

이전 기준:
* UI 구성 요소
* 여러 Feature에서 재사용
* Presentation 레이어에서 공통 사용

이 기준에 맞는 View만 DesignSystem에 포함하도록 정리했습니다.

## 4. 의존성 방향

정리된 의존성 구조는 다음과 같습니다.

```
Presentation → DesignSystem
Presentation → Core
```
DesignSystem은 다른 모듈에 의존하지 않으며,
단방향 UI 의존성만 유지하도록 구성했습니다.

## 5. 의존성 제거 작업

### 1. SnackbarFactory → ImageLoader 의존 제거

기존
* DesignSystem 내부에서 ImageLoader 직접 사용

문제
* UI 모듈이 Core 모듈에 의존

수정
* ImageLoader 외부 주입 방식으로 변경
* DesignSystem 내부 직접 의존 제거

→ UI 모듈 순수성 유지

### 2. BaseViewController → CustomTabBar 의존 제거

문제
* BaseViewController가 TabBar 구현에 의존
* 모듈 간 순환 의존성 가능성 발생

수정
* BaseViewController에서 CustomTabBar 의존 제거

## 6. SPM 리소스 접근 방식 변경

SPM 모듈 분리로 인해 Asset 접근 방식이 변경되었습니다.

기존

```
UIImage.check
UIImage(named: "check")
```

변경

```
DesignSystemAsset.image(.check)
```

SPM 번들 리소스 접근을 위해 Asset Helper를 추가하고
기존 UIImage 직접 접근 코드를 수정했습니다.

## 결론
* DesignSystem을 순수 UI 모듈로 정리
* 공통 인프라는 Core 모듈로 분리
* UI 모듈에서 Core 모듈 의존성 제거
* 필요한 기능은 외부 주입 방식으로 변경

+ PS: BaseViewController에서 탭바를 숨기기위해 UIViewController extension을 이용하는데 이러면 Core에 위치하지만 UIKit이 필요.. 올바른 구조가 맞는지 논의가 필요할듯..