### PR TITLE
알림 관련 API 도메인을 수정 + 버그 픽스

### DIFF
--- a/MLS/Data/Data/Network/DTO/AlarmDTO/AlarmResponseDTO.swift
+++ b/MLS/Data/Data/Network/DTO/AlarmDTO/AlarmResponseDTO.swift
@@ -32,6 +32,7 @@ public struct AlarmResponseDTO: Decodable {
     }
 
     public struct NormalContent: Decodable {
+        public let id: Int
         public let type: String
         public let title: String
         public let link: String
@@ -50,6 +51,7 @@ public extension AlarmResponseDTO {
             switch content {
             case .normal(let normal):
                 return AlarmResponse(
+                    id: normal.id,
                     type: normal.type,
                     title: normal.title,
                     link: normal.link,
@@ -57,6 +59,7 @@ public extension AlarmResponseDTO {
                 )
             case .all(let all):
                 return AlarmResponse(
+                    id: all.alrim.id,
                     type: all.alrim.type,
                     title: all.alrim.title,
                     link: all.alrim.link,
@@ -72,6 +75,7 @@ public extension AlarmResponseDTO {
             switch content {
             case .all(let all):
                 return AllAlarmResponse(
+                    id: all.alrim.id,
                     type: all.alrim.type,
                     title: all.alrim.title,
                     link: all.alrim.link,

--- a/MLS/Data/Data/Network/Endpoints/AlarmEndPoint.swift
+++ b/MLS/Data/Data/Network/Endpoints/AlarmEndPoint.swift
@@ -6,7 +6,7 @@ public enum AlarmEndPoint {
     public static func fetchPatchNotes(query: Encodable) -> ResponsableEndPoint<AlarmResponseDTO> {
         .init(
             baseURL: base,
-            path: "/api/v1/alrim/list/patch-notes",
+            path: "/api/v2/alrim/list/patch-notes",
             method: .GET,
             query: query
         )
@@ -15,7 +15,7 @@ public enum AlarmEndPoint {
     public static func fetchNotices(query: Encodable) -> ResponsableEndPoint<AlarmResponseDTO> {
         .init(
             baseURL: base,
-            path: "/api/v1/alrim/list/notices",
+            path: "/api/v2/alrim/list/notices",
             method: .GET,
             query: query
         )
@@ -24,7 +24,7 @@ public enum AlarmEndPoint {
     public static func fetchOutdatedEvents(query: Encodable) -> ResponsableEndPoint<AlarmResponseDTO> {
         .init(
             baseURL: base,
-            path: "/api/v1/alrim/list/events/outdated",
+            path: "/api/v2/alrim/list/events/outdated",
             method: .GET,
             query: query
         )
@@ -33,7 +33,7 @@ public enum AlarmEndPoint {
     public static func fetchOngoingEvents(query: Encodable) -> ResponsableEndPoint<AlarmResponseDTO> {
         .init(
             baseURL: base,
-            path: "/api/v1/alrim/list/events/ongoing",
+            path: "/api/v2/alrim/list/events/ongoing",
             method: .GET,
             query: query
         )
@@ -42,7 +42,7 @@ public enum AlarmEndPoint {
     public static func fetchAll(query: Encodable) -> ResponsableEndPoint<AlarmResponseDTO> {
         .init(
             baseURL: base,
-            path: "/api/v1/alrim/all",
+            path: "/api/v2/alrim/all",
             method: .GET,
             query: query
         )

--- a/MLS/Data/Data/Repository/AlarmAPIRepositoryImpl.swift
+++ b/MLS/Data/Data/Repository/AlarmAPIRepositoryImpl.swift
@@ -13,31 +13,31 @@ public class AlarmAPIRepositoryImpl: AlarmAPIRepository {
         self.tokenInterceptor = interceptor
     }
 
-    public func fetchPatchNotes(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
+    public func fetchPatchNotes(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
         let endpoint = AlarmEndPoint.fetchPatchNotes(query: AlarmQuery(cursor: cursor, pageSize: pageSize))
         return provider.requestData(endPoint: endpoint, interceptor: tokenInterceptor)
             .map { $0.toAlarmDomain() }
     }
 
-    public func fetchNotices(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
+    public func fetchNotices(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
         let endpoint = AlarmEndPoint.fetchNotices(query: AlarmQuery(cursor: cursor, pageSize: pageSize))
         return provider.requestData(endPoint: endpoint, interceptor: tokenInterceptor)
             .map { $0.toAlarmDomain() }
     }
 
-    public func fetchOutdatedEvents(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
+    public func fetchOutdatedEvents(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
         let endpoint = AlarmEndPoint.fetchOutdatedEvents(query: AlarmQuery(cursor: cursor, pageSize: pageSize))
         return provider.requestData(endPoint: endpoint, interceptor: tokenInterceptor)
             .map { $0.toAlarmDomain() }
     }
 
-    public func fetchOngoingEvents(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
+    public func fetchOngoingEvents(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
         let endpoint = AlarmEndPoint.fetchOngoingEvents(query: AlarmQuery(cursor: cursor, pageSize: pageSize))
         return provider.requestData(endPoint: endpoint, interceptor: tokenInterceptor)
             .map { $0.toAlarmDomain() }
     }
 
-    public func fetchAll(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AllAlarmResponse>> {
+    public func fetchAll(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AllAlarmResponse>> {
         let endpoint = AlarmEndPoint.fetchAll(query: AlarmQuery(cursor: cursor, pageSize: pageSize))
         return provider.requestData(endPoint: endpoint, interceptor: tokenInterceptor)
             .map { $0.toAllAlarmDomain() }
@@ -52,7 +52,7 @@ public class AlarmAPIRepositoryImpl: AlarmAPIRepository {
 
 private extension AlarmAPIRepositoryImpl {
     struct AlarmQuery: Encodable {
-        let cursor: String?
+        let cursor: Int?
         let pageSize: Int
     }
 

--- a/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchAllAlarmUseCaseImpl.swift
+++ b/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchAllAlarmUseCaseImpl.swift
@@ -11,7 +11,7 @@ public class FetchAllAlarmUseCaseImpl: FetchAllAlarmUseCase {
         self.repository = repository
     }
 
-    public func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AllAlarmResponse>> {
-        return repository.fetchAll(cursor: cursor, pageSize: pageSize)
+    public func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AllAlarmResponse>> {
+        return repository.fetchAll(cursor: id, pageSize: pageSize)
     }
 }

--- a/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchNoticesUseCaseImpl.swift
+++ b/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchNoticesUseCaseImpl.swift
@@ -11,7 +11,7 @@ public class FetchNoticesUseCaseImpl: FetchNoticesUseCase {
         self.repository = repository
     }
 
-    public func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
-        return repository.fetchNotices(cursor: cursor, pageSize: pageSize)
+    public func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
+        return repository.fetchNotices(cursor: id, pageSize: pageSize)
     }
 }

--- a/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchOngoingEventsUseCaseImpl.swift
+++ b/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchOngoingEventsUseCaseImpl.swift
@@ -11,7 +11,7 @@ public class FetchOngoingEventsUseCaseImpl: FetchOngoingEventsUseCase {
         self.repository = repository
     }
 
-    public func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
-        return repository.fetchOngoingEvents(cursor: cursor, pageSize: pageSize)
+    public func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
+        return repository.fetchOngoingEvents(cursor: id, pageSize: pageSize)
     }
 }

--- a/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchOutdatedEventsUseCaseImpl.swift
+++ b/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchOutdatedEventsUseCaseImpl.swift
@@ -11,7 +11,7 @@ public class FetchOutdatedEventsUseCaseImpl: FetchOutdatedEventsUseCase {
         self.repository = repository
     }
 
-    public func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
-        return repository.fetchOutdatedEvents(cursor: cursor, pageSize: pageSize)
+    public func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
+        return repository.fetchOutdatedEvents(cursor: id, pageSize: pageSize)
     }
 }

--- a/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchPatchNotesUseCaseImpl.swift
+++ b/MLS/Domain/Domain/UseCaseImpl/Alarm/FetchPatchNotesUseCaseImpl.swift
@@ -11,7 +11,7 @@ public class FetchPatchNotesUseCaseImpl: FetchPatchNotesUseCase {
         self.repository = repository
     }
 
-    public func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
-        return repository.fetchPatchNotes(cursor: cursor, pageSize: pageSize)
+    public func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>> {
+        return repository.fetchPatchNotes(cursor: id, pageSize: pageSize)
     }
 }

--- a/MLS/Domain/DomainInterface/Entity/Alarm/AlarmResponse.swift
+++ b/MLS/Domain/DomainInterface/Entity/Alarm/AlarmResponse.swift
@@ -1,12 +1,14 @@
 import Foundation
 
 public struct AlarmResponse: Equatable {
+    public let id: Int
     public let type: String
     public let title: String
     public let link: String
     public let date: String
 
-    public init(type: String, title: String, link: String, date: String) {
+    public init(id: Int, type: String, title: String, link: String, date: String) {
+        self.id = id
         self.type = type
         self.title = title
         self.link = link
@@ -15,13 +17,15 @@ public struct AlarmResponse: Equatable {
 }
 
 public struct AllAlarmResponse: Equatable {
+    public let id: Int
     public let type: String
     public let title: String
     public let link: String
     public let date: String
     public var alreadyRead: Bool
 
-    public init(type: String, title: String, link: String, date: String, alreadyRead: Bool) {
+    public init(id: Int, type: String, title: String, link: String, date: String, alreadyRead: Bool) {
+        self.id = id
         self.type = type
         self.title = title
         self.link = link

--- a/MLS/Domain/DomainInterface/Repository/AlarmAPIRepository.swift
+++ b/MLS/Domain/DomainInterface/Repository/AlarmAPIRepository.swift
@@ -3,15 +3,15 @@ import Foundation
 import RxSwift
 
 public protocol AlarmAPIRepository {
-    func fetchPatchNotes(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
+    func fetchPatchNotes(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
 
-    func fetchNotices(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
+    func fetchNotices(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
 
-    func fetchOutdatedEvents(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
+    func fetchOutdatedEvents(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
 
-    func fetchOngoingEvents(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
+    func fetchOngoingEvents(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
 
-    func fetchAll(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AllAlarmResponse>>
+    func fetchAll(cursor: Int?, pageSize: Int) -> Observable<PagedEntity<AllAlarmResponse>>
 
     func setRead(alarmLink: String) -> Completable
 }

--- a/MLS/Domain/DomainInterface/UseCase/Alarm/FetchAllAlarmUseCase.swift
+++ b/MLS/Domain/DomainInterface/UseCase/Alarm/FetchAllAlarmUseCase.swift
@@ -1,5 +1,5 @@
 import RxSwift
 
 public protocol FetchAllAlarmUseCase {
-    func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AllAlarmResponse>>
+    func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AllAlarmResponse>>
 }

--- a/MLS/Domain/DomainInterface/UseCase/Alarm/FetchNoticesUseCase.swift
+++ b/MLS/Domain/DomainInterface/UseCase/Alarm/FetchNoticesUseCase.swift
@@ -1,5 +1,5 @@
 import RxSwift
 
 public protocol FetchNoticesUseCase {
-    func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
+    func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
 }

--- a/MLS/Domain/DomainInterface/UseCase/Alarm/FetchOngoingEventsUseCase.swift
+++ b/MLS/Domain/DomainInterface/UseCase/Alarm/FetchOngoingEventsUseCase.swift
@@ -1,5 +1,5 @@
 import RxSwift
 
 public protocol FetchOngoingEventsUseCase {
-    func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
+    func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
 }

--- a/MLS/Domain/DomainInterface/UseCase/Alarm/FetchOutdatedEventsUseCase.swift
+++ b/MLS/Domain/DomainInterface/UseCase/Alarm/FetchOutdatedEventsUseCase.swift
@@ -1,5 +1,5 @@
 import RxSwift
 
 public protocol FetchOutdatedEventsUseCase {
-    func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
+    func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
 }

--- a/MLS/Domain/DomainInterface/UseCase/Alarm/FetchPatchNotesUseCase.swift
+++ b/MLS/Domain/DomainInterface/UseCase/Alarm/FetchPatchNotesUseCase.swift
@@ -1,5 +1,5 @@
 import RxSwift
 
 public protocol FetchPatchNotesUseCase {
-    func execute(cursor: String?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
+    func execute(id: Int?, pageSize: Int) -> Observable<PagedEntity<AlarmResponse>>
 }

--- a/MLS/MLS.xcodeproj/project.pbxproj
+++ b/MLS/MLS.xcodeproj/project.pbxproj
@@ -681,6 +681,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = W5QTRMS954;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MLS/Resource/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "메랜사";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -693,7 +694,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_execute;
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.donggle.MLS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -723,6 +724,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = W5QTRMS954;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MLS/Resource/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "메랜사";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -735,7 +737,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_execute;
-				MARKETING_VERSION = 3.0.2;
+				MARKETING_VERSION = 3.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.donggle.MLS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MLS/Presentation/DictionaryFeature/DictionaryFeature/DictionaryNotification/DictionaryNotificationReactor.swift
+++ b/MLS/Presentation/DictionaryFeature/DictionaryFeature/DictionaryNotification/DictionaryNotificationReactor.swift
@@ -63,7 +63,7 @@ public final class DictionaryNotificationReactor: Reactor {
 
             let notificationStream: Observable<Mutation> = Observable.concat([
                 Observable<Mutation>.just(.setLoading(true)),
-                fetchAllAlarmUseCase.execute(cursor: nil, pageSize: 20)
+                fetchAllAlarmUseCase.execute(id: nil, pageSize: 20)
                     .map { paged in
                         Mutation.setNotifications(paged.items, hasMore: paged.hasMore, reset: true)
                     },
@@ -78,11 +78,11 @@ public final class DictionaryNotificationReactor: Reactor {
 
         case .loadMore:
             guard currentState.hasMore, !currentState.isLoading else { return .empty() }
-            let cursor = currentState.notifications.last?.date
+            let cursor = currentState.notifications.last?.id
 
             return Observable.concat([
                 Observable<Mutation>.just(.setLoading(true)),
-                fetchAllAlarmUseCase.execute(cursor: cursor, pageSize: 20)
+                fetchAllAlarmUseCase.execute(id: cursor, pageSize: 20)
                     .map { paged in
                         Mutation.setNotifications(paged.items, hasMore: paged.hasMore, reset: false)
                     },

--- a/MLS/Presentation/MyPageFeature/MyPageFeature.xcodeproj/project.pbxproj
+++ b/MLS/Presentation/MyPageFeature/MyPageFeature.xcodeproj/project.pbxproj
@@ -27,10 +27,6 @@
 		773A3F6F2E71736300F75B30 /* BaseFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 773A3F6D2E71736300F75B30 /* BaseFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		773A3F712E71736A00F75B30 /* BaseFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 773A3F702E71736A00F75B30 /* BaseFeature.framework */; };
 		773A42D02E717B8900F75B30 /* BaseFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 773A42CF2E717B8900F75B30 /* BaseFeature.framework */; };
-		7746A7EF2E841C9C0046F603 /* Data.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7746A7EE2E841C9C0046F603 /* Data.framework */; };
-		7746A7F02E841C9C0046F603 /* Data.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7746A7EE2E841C9C0046F603 /* Data.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		7746A7F22E841CEA0046F603 /* DataMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7746A7F12E841CEA0046F603 /* DataMock.framework */; };
-		7746A7F32E841CEA0046F603 /* DataMock.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7746A7F12E841CEA0046F603 /* DataMock.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7746ABAA2E84225A0046F603 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7746ABA92E84225A0046F603 /* Core.framework */; };
 		7746ABAB2E84225A0046F603 /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7746ABA92E84225A0046F603 /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7746ABAD2E84227A0046F603 /* DomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7746ABAC2E84227A0046F603 /* DomainInterface.framework */; };
@@ -38,13 +34,11 @@
 		7746ABB32E8425E00046F603 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7746ABB22E8425E00046F603 /* DesignSystem.framework */; };
 		7746ABB72E8427F80046F603 /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = 7746ABB62E8427F80046F603 /* RxKeyboard */; };
 		775966F32EC30B3A00CC389B /* AuthFeatureInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 775966F22EC30B3A00CC389B /* AuthFeatureInterface.framework */; };
-		776FEA342EA4D29B0039ACE2 /* AuthFeatureInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 776FEA332EA4D29B0039ACE2 /* AuthFeatureInterface.framework */; };
-		776FEA352EA4D29B0039ACE2 /* AuthFeatureInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 776FEA332EA4D29B0039ACE2 /* AuthFeatureInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		777C28142E7D87B8000765F2 /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = 777C28132E7D87B8000765F2 /* RxKeyboard */; };
-		77BE55BA2E78596900522216 /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77BE55B82E78596900522216 /* Domain.framework */; };
-		77BE55BB2E78596900522216 /* Domain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77BE55B82E78596900522216 /* Domain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		77BE55BC2E78596900522216 /* DomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77BE55B92E78596900522216 /* DomainInterface.framework */; };
 		77BE55BD2E78596900522216 /* DomainInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77BE55B92E78596900522216 /* DomainInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		77D0AD422F97DA78008B0C57 /* AuthFeatureInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77D0AD412F97DA78008B0C57 /* AuthFeatureInterface.framework */; };
+		77D0AD432F97DA78008B0C57 /* AuthFeatureInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77D0AD412F97DA78008B0C57 /* AuthFeatureInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D22195C52E83FA81001203D4 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = D22195C42E83FA81001203D4 /* RxGesture */; };
 		D2DA8C322E798917009C53BA /* ReactorKit in Frameworks */ = {isa = PBXBuildFile; productRef = D2227A7C2E76A84A0095343A /* ReactorKit */; };
 /* End PBXBuildFile section */
@@ -80,13 +74,10 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				77D0AD432F97DA78008B0C57 /* AuthFeatureInterface.framework in Embed Frameworks */,
 				77BE55BD2E78596900522216 /* DomainInterface.framework in Embed Frameworks */,
-				77BE55BB2E78596900522216 /* Domain.framework in Embed Frameworks */,
-				7746A7F32E841CEA0046F603 /* DataMock.framework in Embed Frameworks */,
-				776FEA352EA4D29B0039ACE2 /* AuthFeatureInterface.framework in Embed Frameworks */,
 				773A3F6F2E71736300F75B30 /* BaseFeature.framework in Embed Frameworks */,
 				773A3F6C2E71734600F75B30 /* DesignSystem.framework in Embed Frameworks */,
-				7746A7F02E841C9C0046F603 /* Data.framework in Embed Frameworks */,
 				773A3F672E71731700F75B30 /* MyPageFeature.framework in Embed Frameworks */,
 				7746ABAB2E84225A0046F603 /* Core.framework in Embed Frameworks */,
 				773A3C002E7170A700F75B30 /* MyPageFeatureInterface.framework in Embed Frameworks */,
@@ -113,6 +104,7 @@
 		776FEA332EA4D29B0039ACE2 /* AuthFeatureInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AuthFeatureInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77BE55B82E78596900522216 /* Domain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Domain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77BE55B92E78596900522216 /* DomainInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DomainInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		77D0AD412F97DA78008B0C57 /* AuthFeatureInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AuthFeatureInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2227A762E76A7E70095343A /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -179,20 +171,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7746A7EF2E841C9C0046F603 /* Data.framework in Frameworks */,
 				D2DA8C322E798917009C53BA /* ReactorKit in Frameworks */,
 				77BE55BC2E78596900522216 /* DomainInterface.framework in Frameworks */,
 				773A3F6E2E71736300F75B30 /* BaseFeature.framework in Frameworks */,
 				773A3F6B2E71734600F75B30 /* DesignSystem.framework in Frameworks */,
 				7746ABB72E8427F80046F603 /* RxKeyboard in Frameworks */,
 				773A3F662E71731700F75B30 /* MyPageFeature.framework in Frameworks */,
-				77BE55BA2E78596900522216 /* Domain.framework in Frameworks */,
 				7746ABB12E84245D0046F603 /* RxGesture in Frameworks */,
+				77D0AD422F97DA78008B0C57 /* AuthFeatureInterface.framework in Frameworks */,
 				7746ABAA2E84225A0046F603 /* Core.framework in Frameworks */,
 				773A3BFC2E71701D00F75B30 /* RxSwift in Frameworks */,
 				773A3BFE2E71702300F75B30 /* SnapKit in Frameworks */,
-				776FEA342EA4D29B0039ACE2 /* AuthFeatureInterface.framework in Frameworks */,
-				7746A7F22E841CEA0046F603 /* DataMock.framework in Frameworks */,
 				773A3BFA2E71701D00F75B30 /* RxRelay in Frameworks */,
 				773A3BF82E71701D00F75B30 /* RxCocoa in Frameworks */,
 				773A3BFF2E7170A700F75B30 /* MyPageFeatureInterface.framework in Frameworks */,
@@ -226,6 +215,7 @@
 		773A3BF62E71701D00F75B30 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				77D0AD412F97DA78008B0C57 /* AuthFeatureInterface.framework */,
 				775966F22EC30B3A00CC389B /* AuthFeatureInterface.framework */,
 				776FEA332EA4D29B0039ACE2 /* AuthFeatureInterface.framework */,
 				7746ABB22E8425E00046F603 /* DesignSystem.framework */,

--- a/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/Announcement/AnnouncementReactor.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/Announcement/AnnouncementReactor.swift
@@ -42,7 +42,7 @@ public final class AnnouncementReactor: Reactor {
         case .viewWillAppear:
             return .concat([
                 .just(.setLoading(true)),
-                fetchNoticesUseCase.execute(cursor: nil, pageSize: 20)
+                fetchNoticesUseCase.execute(id: nil, pageSize: 20)
                     .map { paged in
                         .setAlarms(paged.items, hasMore: paged.hasMore, reset: true)
                     },
@@ -50,10 +50,10 @@ public final class AnnouncementReactor: Reactor {
             ])
         case .loadMore:
             guard currentState.hasMore, !currentState.isLoading else { return .empty() }
-            let lastCursor = currentState.alarms.last?.date
+            let lastCursor = currentState.alarms.last?.id
             return .concat([
                 .just(.setLoading(true)),
-                fetchNoticesUseCase.execute(cursor: lastCursor, pageSize: 20)
+                fetchNoticesUseCase.execute(id: lastCursor, pageSize: 20)
                     .map { paged in
                         .setAlarms(paged.items, hasMore: paged.hasMore, reset: false)
                     },

--- a/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/Announcement/AnnouncementViewController.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/Announcement/AnnouncementViewController.swift
@@ -50,8 +50,12 @@ extension AnnouncementViewController {
             .distinctUntilChanged()
             .withUnretained(self)
             .observe(on: MainScheduler.instance)
-            .bind(onNext: { owner, _ in
-                owner.createDetailItem(items: reactor.currentState.alarms)
+            .bind(onNext: { owner, items in
+                owner.mainView.detailItemStackView.arrangedSubviews.forEach {
+                    owner.mainView.detailItemStackView.removeArrangedSubview($0)
+                    $0.removeFromSuperview()
+                }
+                owner.createDetailItem(items: items)
             })
             .disposed(by: disposeBag)
     }

--- a/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/Event/EventReactor.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/Event/EventReactor.swift
@@ -45,8 +45,8 @@ public final class EventReactor: Reactor {
         switch action {
         case let .selectTab(index):
             let fetchObservable = (index == 0
-                ? fetchOngoingEventsUseCase.execute(cursor: nil, pageSize: 20)
-                : fetchOutdatedEventsUseCase.execute(cursor: nil, pageSize: 20))
+                ? fetchOngoingEventsUseCase.execute(id: nil, pageSize: 20)
+                : fetchOutdatedEventsUseCase.execute(id: nil, pageSize: 20))
                 .map { paged -> Mutation in
                     .setAlarms(paged.items, hasMore: paged.hasMore, reset: true)
                 }
@@ -64,11 +64,11 @@ public final class EventReactor: Reactor {
 
         case .loadMore:
             guard currentState.hasMore, !currentState.isLoading else { return .empty() }
-            let lastCursor = currentState.alarms.last?.date
+            let lastCursor = currentState.alarms.last?.id
 
             return .concat([
                 .just(.setLoading(true)),
-                (currentState.selectedIndex == 0 ? fetchOngoingEventsUseCase.execute(cursor: lastCursor, pageSize: 20) : fetchOutdatedEventsUseCase.execute(cursor: lastCursor, pageSize: 20))
+                (currentState.selectedIndex == 0 ? fetchOngoingEventsUseCase.execute(id: lastCursor, pageSize: 20) : fetchOutdatedEventsUseCase.execute(id: lastCursor, pageSize: 20))
                     .map { paged in
                         .setAlarms(paged.items, hasMore: paged.hasMore, reset: false)
                     },

--- a/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/Event/EventViewController.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/Event/EventViewController.swift
@@ -32,8 +32,6 @@ final class EventViewController: CustomerSupportBaseViewController, View {
         mainView.menuStackView.addArrangedSubview(endedButton)
         mainView.setupSpacerView()
 
-        reactor?.action.onNext(.selectTab(0))
-
         guard let reactor = reactor else { return }
         mainView.menuStackView.arrangedSubviews
             .compactMap { $0 as? UIButton }
@@ -49,6 +47,7 @@ final class EventViewController: CustomerSupportBaseViewController, View {
 // MARK: - Bind
 extension EventViewController {
     func bind(reactor: Reactor) {
+        reactor.action.onNext(.selectTab(0))
         bindViewState(reactor: reactor)
     }
 

--- a/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/PatchNote/PatchNoteReactor.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/PatchNote/PatchNoteReactor.swift
@@ -42,7 +42,7 @@ public final class PatchNoteReactor: Reactor {
         case .viewWillAppear:
             return .concat([
                 .just(.setLoading(true)),
-                fetchPatchNotesUseCase.execute(cursor: nil, pageSize: 20)
+                fetchPatchNotesUseCase.execute(id: nil, pageSize: 20)
                     .map { paged in
                         .setAlarms(paged.items, hasMore: paged.hasMore, reset: true)
                     },
@@ -50,10 +50,10 @@ public final class PatchNoteReactor: Reactor {
             ])
         case .loadMore:
             guard currentState.hasMore, !currentState.isLoading else { return .empty() }
-            let lastCursor = currentState.alarms.last?.date
+            let lastCursor = currentState.alarms.last?.id
             return .concat([
                 .just(.setLoading(true)),
-                fetchPatchNotesUseCase.execute(cursor: lastCursor, pageSize: 20)
+                fetchPatchNotesUseCase.execute(id: lastCursor, pageSize: 20)
                     .map { paged in
                         .setAlarms(paged.items, hasMore: paged.hasMore, reset: false)
                     },

--- a/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/PatchNote/PatchNoteViewController.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeature/CustomerSupport/PatchNote/PatchNoteViewController.swift
@@ -50,8 +50,12 @@ extension PatchNoteViewController {
             .distinctUntilChanged()
             .withUnretained(self)
             .observe(on: MainScheduler.instance)
-            .bind(onNext: { owner, _ in
-                owner.createDetailItem(items: reactor.currentState.alarms)
+            .bind(onNext: { owner, alarms in
+                owner.mainView.detailItemStackView.arrangedSubviews.forEach {
+                    owner.mainView.detailItemStackView.removeArrangedSubview($0)
+                    $0.removeFromSuperview()
+                }
+                owner.createDetailItem(items: alarms)
             })
             .disposed(by: disposeBag)
     }

--- a/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/AppDelegate.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/AppDelegate.swift
@@ -56,7 +56,7 @@ private extension AppDelegate {
     }
 
     func registerUseCase() {
-        ///테스트 코드에 맞게 등록
+        /// 테스트 코드에 맞게 등록
 //        DIContainer.register(type: CheckNickNameUseCase.self) {
 //            CheckNickNameUseCaseImpl()
 //        }

--- a/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/AppDelegate.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/AppDelegate.swift
@@ -5,10 +5,7 @@ import UIKit
 import AuthFeatureInterface
 import BaseFeature
 import Core
-import Data
-import DataMock
 import DesignSystem
-import Domain
 import DomainInterface
 import MyPageFeature
 import MyPageFeatureInterface
@@ -54,91 +51,69 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
 private extension AppDelegate {
     func registerDependencies() {
-        registerProvider()
-        registerRepository()
         registerUseCase()
         registerFactory()
     }
 
-    func registerProvider() {
-        DIContainer.register(type: NetworkProvider.self) {
-            NetworkProviderImpl()
-        }
-        DIContainer.register(type: Interceptor.self) {
-            TokenInterceptor(fetchTokenUseCase: DIContainer.resolve(type: FetchTokenFromLocalUseCase.self))
-        }
-    }
-
-    func registerRepository() {
-        DIContainer.register(type: TokenRepository.self) {
-            KeyChainRepositoryImpl()
-        }
-        DIContainer.register(type: AuthAPIRepository.self) {
-            AuthAPIRepositoryImpl(provider: DIContainer.resolve(type: NetworkProvider.self), interceptor: TokenInterceptor(fetchTokenUseCase: DIContainer.resolve(type: FetchTokenFromLocalUseCase.self)))
-        }
-        DIContainer.register(type: AlarmAPIRepository.self) {
-            AlarmAPIRepositoryImpl(provider: DIContainer.resolve(type: NetworkProvider.self), interceptor: DIContainer.resolve(type: Interceptor.self))
-        }
-    }
-
     func registerUseCase() {
-        DIContainer.register(type: CheckNickNameUseCase.self) {
-            CheckNickNameUseCaseImpl()
-        }
-        DIContainer.register(type: CheckEmptyLevelAndRoleUseCase.self) {
-            CheckEmptyLevelAndRoleUseCaseImpl()
-        }
-        DIContainer.register(type: CheckValidLevelUseCase.self) {
-            CheckValidLevelUseCaseImpl()
-        }
-        DIContainer.register(type: FetchJobListUseCase.self) {
-            FetchJobListUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
-        }
-        DIContainer.register(type: UpdateUserInfoUseCase.self) {
-            UpdateUserInfoUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
-        }
-        DIContainer.register(type: UpdateNickNameUseCase.self) {
-            UpdateNickNameUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
-        }
-        DIContainer.register(type: LogoutUseCase.self) {
-            LogoutUseCaseImpl(repository: DIContainer.resolve(type: TokenRepository.self))
-        }
-        DIContainer.register(type: WithdrawUseCase.self) {
-            WithdrawUseCaseImpl(authRepository: DIContainer.resolve(type: AuthAPIRepository.self), tokenRepository: DIContainer.resolve(type: TokenRepository.self))
-        }
-        DIContainer.register(type: FetchTokenFromLocalUseCase.self) {
-            FetchTokenFromLocalUseCaseImpl(repository: DIContainer.resolve(type: TokenRepository.self))
-        }
-        DIContainer.register(type: FetchNoticesUseCase.self) {
-            FetchNoticesUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
-        }
-        DIContainer.register(type: FetchOngoingEventsUseCase.self) {
-            FetchOngoingEventsUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
-        }
-        DIContainer.register(type: FetchOutdatedEventsUseCase.self) {
-            FetchOutdatedEventsUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
-        }
-        DIContainer.register(type: FetchPatchNotesUseCase.self) {
-            FetchPatchNotesUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
-        }
-        DIContainer.register(type: SetReadUseCase.self) {
-            SetReadUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
-        }
-        DIContainer.register(type: CheckNotificationPermissionUseCase.self) {
-            CheckNotificationPermissionUseCaseImpl()
-        }
-        DIContainer.register(type: UpdateNotificationAgreementUseCase.self) {
-            UpdateNotificationAgreementUseCaseImpl(authRepository: DIContainer.resolve(type: AuthAPIRepository.self))
-        }
-        DIContainer.register(type: UpdateProfileImageUseCase.self) {
-            UpdateProfileImageUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
-        }
-        DIContainer.register(type: FetchJobUseCase.self) {
-            FetchJobUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
-        }
-        DIContainer.register(type: FetchProfileUseCase.self) {
-            FetchProfileUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self), fetchJobUseCase: DIContainer.resolve(type: FetchJobUseCase.self))
-        }
+        ///테스트 코드에 맞게 등록
+//        DIContainer.register(type: CheckNickNameUseCase.self) {
+//            CheckNickNameUseCaseImpl()
+//        }
+//        DIContainer.register(type: CheckEmptyLevelAndRoleUseCase.self) {
+//            CheckEmptyLevelAndRoleUseCaseImpl()
+//        }
+//        DIContainer.register(type: CheckValidLevelUseCase.self) {
+//            CheckValidLevelUseCaseImpl()
+//        }
+//        DIContainer.register(type: FetchJobListUseCase.self) {
+//            FetchJobListUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
+//        }
+//        DIContainer.register(type: UpdateUserInfoUseCase.self) {
+//            UpdateUserInfoUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
+//        }
+//        DIContainer.register(type: UpdateNickNameUseCase.self) {
+//            UpdateNickNameUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
+//        }
+//        DIContainer.register(type: LogoutUseCase.self) {
+//            LogoutUseCaseImpl(repository: DIContainer.resolve(type: TokenRepository.self))
+//        }
+//        DIContainer.register(type: WithdrawUseCase.self) {
+//            WithdrawUseCaseImpl(authRepository: DIContainer.resolve(type: AuthAPIRepository.self), tokenRepository: DIContainer.resolve(type: TokenRepository.self))
+//        }
+//        DIContainer.register(type: FetchTokenFromLocalUseCase.self) {
+//            FetchTokenFromLocalUseCaseImpl(repository: DIContainer.resolve(type: TokenRepository.self))
+//        }
+//        DIContainer.register(type: FetchNoticesUseCase.self) {
+//            FetchNoticesUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
+//        }
+//        DIContainer.register(type: FetchOngoingEventsUseCase.self) {
+//            FetchOngoingEventsUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
+//        }
+//        DIContainer.register(type: FetchOutdatedEventsUseCase.self) {
+//            FetchOutdatedEventsUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
+//        }
+//        DIContainer.register(type: FetchPatchNotesUseCase.self) {
+//            FetchPatchNotesUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
+//        }
+//        DIContainer.register(type: SetReadUseCase.self) {
+//            SetReadUseCaseImpl(repository: DIContainer.resolve(type: AlarmAPIRepository.self))
+//        }
+//        DIContainer.register(type: CheckNotificationPermissionUseCase.self) {
+//            CheckNotificationPermissionUseCaseImpl()
+//        }
+//        DIContainer.register(type: UpdateNotificationAgreementUseCase.self) {
+//            UpdateNotificationAgreementUseCaseImpl(authRepository: DIContainer.resolve(type: AuthAPIRepository.self))
+//        }
+//        DIContainer.register(type: UpdateProfileImageUseCase.self) {
+//            UpdateProfileImageUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
+//        }
+//        DIContainer.register(type: FetchJobUseCase.self) {
+//            FetchJobUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self))
+//        }
+//        DIContainer.register(type: FetchProfileUseCase.self) {
+//            FetchProfileUseCaseImpl(repository: DIContainer.resolve(type: AuthAPIRepository.self), fetchJobUseCase: DIContainer.resolve(type: FetchJobUseCase.self))
+//        }
     }
 
     func registerFactory() {
@@ -147,7 +122,7 @@ private extension AppDelegate {
         }
 
         DIContainer.register(type: SetProfileFactory.self) {
-            SetProfileFactoryImpl(selectImageFactory: DIContainer.resolve(type: SelectImageFactory.self), checkNickNameUseCase: DIContainer.resolve(type: CheckNickNameUseCase.self), updateNickNameUseCase: DIContainer.resolve(type: UpdateNickNameUseCase.self), logoutUseCase: DIContainer.resolve(type: LogoutUseCase.self), withdrawUseCase: DIContainer.resolve(type: WithdrawUseCase.self))
+            SetProfileFactoryImpl(selectImageFactory: DIContainer.resolve(type: SelectImageFactory.self), checkNickNameUseCase: DIContainer.resolve(type: CheckNickNameUseCase.self), updateNickNameUseCase: DIContainer.resolve(type: UpdateNickNameUseCase.self), logoutUseCase: DIContainer.resolve(type: LogoutUseCase.self), withdrawUseCase: DIContainer.resolve(type: WithdrawUseCase.self), fetchProfileUseCase: DIContainer.resolve(type: FetchProfileUseCase.self))
         }
 
         DIContainer.register(type: SetCharacterFactory.self) {
@@ -177,14 +152,15 @@ private extension AppDelegate {
         }
 
         DIContainer.register(type: CustomerSupportFactory.self) {
-            CustomerSupportBaseViewFactoryImpl(fetchNoticesUseCase: DIContainer.resolve(type: FetchNoticesUseCase.self), fetchOngoingEventsUseCase: DIContainer.resolve(type: FetchOngoingEventsUseCase.self), fetchOutdatedEventsUseCase: DIContainer.resolve(type: FetchOutdatedEventsUseCase.self), fetchPatchNotesUseCase: DIContainer.resolve(type: FetchPatchNotesUseCase.self), setReadUseCase: DIContainer.resolve(type: SetReadUseCase.self))
+            CustomerSupportBaseViewFactoryImpl(policyFactory: DIContainer.resolve(type: PolicyFactory.self), fetchNoticesUseCase: DIContainer.resolve(type: FetchNoticesUseCase.self), fetchOngoingEventsUseCase: DIContainer.resolve(type: FetchOngoingEventsUseCase.self), fetchOutdatedEventsUseCase: DIContainer.resolve(type: FetchOutdatedEventsUseCase.self), fetchPatchNotesUseCase: DIContainer.resolve(type: FetchPatchNotesUseCase.self), setReadUseCase: DIContainer.resolve(type: SetReadUseCase.self))
         }
 
         DIContainer.register(type: NotificationSettingFactory.self) {
             NotificationSettingFactoryImpl(checkNotificationPermissionUseCase: DIContainer.resolve(type: CheckNotificationPermissionUseCase.self), updateNotificationAgreementUseCase: DIContainer.resolve(type: UpdateNotificationAgreementUseCase.self))
         }
+
         DIContainer.register(type: LoginFactory.self) {
-            LoginFactoryMock()
+            MockLoginFactory()
         }
     }
 }

--- a/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/Mock/MockLoginFactory.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/Mock/MockLoginFactory.swift
@@ -1,5 +1,5 @@
-import BaseFeature
 import AuthFeatureInterface
+import BaseFeature
 
 public final class MockLoginFactory: LoginFactory {
     public func make(exitRoute: LoginExitRoute, onLoginCompleted: (() -> Void)?) -> BaseViewController {

--- a/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/Mock/MockLoginFactory.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/Mock/MockLoginFactory.swift
@@ -1,0 +1,10 @@
+import BaseFeature
+import AuthFeatureInterface
+
+public final class MockLoginFactory: LoginFactory {
+    public func make(exitRoute: LoginExitRoute, onLoginCompleted: (() -> Void)?) -> BaseViewController {
+        let viewcontroller = BaseViewController()
+        viewcontroller.view.backgroundColor = .redMLS
+        return viewcontroller
+    }
+}

--- a/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/ViewController.swift
+++ b/MLS/Presentation/MyPageFeature/MyPageFeatureDemo/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
         ])
 
         let notiView = BottomTabBarController(viewControllers: [
-            DIContainer.resolve(type: NotificationSettingFactory.self).make()
+            DIContainer.resolve(type: NotificationSettingFactory.self).make(isAgreeEventNotification: false, isAgreeNoticeNotification: false, isAgreePatchNoteNotification: false)
         ])
 
         mainView.title = "마이페이지 메인"


### PR DESCRIPTION
## 📌 이슈

- #318
- #319

## ✅ 작업 사항

## 1. 공지사항 API 변경 대응
* [메이플랜드 공식 사이트](chatgpt://generic-entity?number=0) 구조 변경으로 기존 공지사항 API 동작 방식 수정이 필요했습니다.
* 기존에는 datetime 기반 커서 페이징을 사용하고 있었으나, 사이트 구조 변경 이후 해당 방식으로 페이징이 불가능해져 id 기반 커서 페이징으로 변경했습니다.
* 알람 관련 API 중 set-read API를 제외한 나머지 엔드포인트를 v1 → v2 도메인으로 변경했습니다.
* 이에 따라 Domain → Repository → UseCase 흐름에서 cursor 타입 및 매핑 로직을 함께 수정했습니다.

## 2. 설정 화면 공지사항 / 패치노트 페이징 UI 이슈 수정
* 페이징 시 기존 뷰를 제거하지 않고 새로운 뷰를 추가하는 방식으로 동작하고 있어 데이터가 중복되는 문제가 발생했습니다.
* 기존 데이터가 유지된 상태에서 전체 데이터가 다시 추가되면서 다음과 같은 문제가 발생했습니다.
```
예시:
* 초기 로드: 20개
* 페이징 후 예상: 기존 20 + 신규 20 = 40개
* 실제 동작: 기존 20 + 전체 40 추가 = 총 60개
```
* StackView 내부 기존 subview를 제거하지 않고 append 형태로 UI를 구성하고 있었던 것이 원인이었습니다.
* 페이징 시마다 기존 뷰를 제거한 뒤 전체 데이터를 기준으로 다시 렌더링하도록 수정하여 완전한 덮어쓰기 방식으로 동작하도록 변경했습니다.

## 3. 종료된 이벤트 링크 이동 이슈
* 종료된 이벤트 클릭 시 잘못된 페이지로 이동하는 현상이 확인되었습니다.
```
예시:
* 앱에서 [루디브리엄의 미로] 클릭
* 실제 이동: [만우절 대소동] 페이지로 이동
```
* 해당 이슈는 재현되지 않는 상태이며, 서버 데이터 또는 링크 매핑 문제 가능성이 있어 추가 관찰이 필요합니다.
* 현재 코드 수정은 진행하지 않고 상태 모니터링 예정입니다.

## 👀 ETC (추후 개발해야 할 것, 참고자료 등)
* 업데이트 예정이므로 v 3.0.2 -> 3.0.3으로 수정
* 팀원들 요청에 따라 앱 이름 MLS -> 메랜사 수정